### PR TITLE
KM-11 fix: OTT 여석 검색 시 OTT를 지정하지 않을 때 NPE 발생 오류 해결

### DIFF
--- a/src/main/java/kkomo/ott/repository/OTTQueryDslRepository.java
+++ b/src/main/java/kkomo/ott/repository/OTTQueryDslRepository.java
@@ -27,8 +27,7 @@ class OTTQueryDslRepository extends QueryDslSupport implements OTTQueryRepositor
                     .and(reservation.profile.eq(profile))
                     .and(reservation.time.start.goe(time.getStart()))
                     .and(reservation.time.end.loe(time.getEnd())))
-                .where(ottNameEq(ottName)
-                    .and(reservation.id.isNull()))
+                .where(ottNameEq(ottName), reservation.id.isNull())
                 .fetch();
     }
 


### PR DESCRIPTION
## ✨ 구현한 기능
- OTT 여석 검색 시 OTT를 지정하지 않을 때 NPE 발생 오류 해결

## 📢 논의하고 싶은 내용
- 

## 🎸 기타
- 