### PR TITLE
KM-18: 로그아웃 API 구현

### DIFF
--- a/src/main/java/kkomo/auth/UserPrincipal.java
+++ b/src/main/java/kkomo/auth/UserPrincipal.java
@@ -49,7 +49,7 @@ public class UserPrincipal implements OAuth2User {
 
     @Override
     public String getName() {
-        return member.getName();
+        return member.getEmail();
     }
 
     @Override

--- a/src/main/java/kkomo/auth/controller/AuthController.java
+++ b/src/main/java/kkomo/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,7 +26,7 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @PostMapping("/login")
+    @GetMapping("/login")
     public RedirectView login() {
         return new RedirectView(authService.getLoginUrl());
     }

--- a/src/main/java/kkomo/auth/handler/CustomLogoutHandler.java
+++ b/src/main/java/kkomo/auth/handler/CustomLogoutHandler.java
@@ -1,0 +1,29 @@
+package kkomo.auth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kkomo.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomLogoutHandler implements LogoutHandler {
+
+    private final AuthService authService;
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
+        log.info("oauth2User : {}", oauth2User.getName());
+
+        String accessToken = authService.getAccessToken(oauth2User.getName());
+
+        authService.logoutFromKakao(accessToken);
+    }
+}

--- a/src/main/java/kkomo/global/config/SecurityConfig.java
+++ b/src/main/java/kkomo/global/config/SecurityConfig.java
@@ -81,7 +81,7 @@ public class SecurityConfig {
                 .logoutRequestMatcher(new AntPathRequestMatcher("/auth/logout","GET"))
                 .addLogoutHandler(customLogoutHandler)
                 .invalidateHttpSession(true)
-                .deleteCookies("JSESSIONID")
+                .clearAuthentication(true)
                 .logoutSuccessUrl("/logoutSuccess") //TODO 리다이렉트될 프론트 주소
             );
         return http.build();

--- a/src/main/java/kkomo/global/config/SecurityConfig.java
+++ b/src/main/java/kkomo/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package kkomo.global.config;
 
 import kkomo.auth.CustomAuthenticationEntryPoint;
+import kkomo.auth.handler.CustomLogoutHandler;
 import kkomo.auth.handler.OAuth2FailureHandler;
 import kkomo.auth.handler.OAuth2SuccessHandler;
 import kkomo.auth.service.OAuth2UserService;
@@ -13,6 +14,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Slf4j
 @Configuration
@@ -24,6 +26,7 @@ public class SecurityConfig {
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomLogoutHandler customLogoutHandler;
 
     @Bean
     public SessionRegistry sessionRegistry() {
@@ -42,7 +45,8 @@ public class SecurityConfig {
                     "/ws/**",
                     "/oauth2/**",
                     "/auth/**",
-                    "/login"
+                    "/login",
+                    "/logoutSuccess"
                 )
                 .permitAll()
                 .requestMatchers(
@@ -72,7 +76,14 @@ public class SecurityConfig {
             .sessionManagement(sessionManagement -> sessionManagement
                 .maximumSessions(1)
                 .sessionRegistry(sessionRegistry())
-                .expiredUrl("/login?expired"));
+                .expiredUrl("/login?expired"))
+            .logout(logout -> logout
+                .logoutRequestMatcher(new AntPathRequestMatcher("/auth/logout","GET"))
+                .addLogoutHandler(customLogoutHandler)
+                .invalidateHttpSession(true)
+                .deleteCookies("JSESSIONID")
+                .logoutSuccessUrl("/logoutSuccess") //TODO 리다이렉트될 프론트 주소
+            );
         return http.build();
     }
 }


### PR DESCRIPTION
## ✨ 구현한 기능
- 로그아웃 요청시 카카오 로그아웃 및 서버 세션 만료
- 카카오 로그아웃은 비동기처리

## 📢 논의하고 싶은 내용
- UserPrincipal에서 getName 메서드를 이름이 아닌 이메일을 가져올 수 있도록 수정했습니다
- 이름은 중복이 발생할 수 있기에 UserPrincipal에서 유효한 유저 정보를 가져오기 위함입니다.
- 카카오 로그아웃(외부 API) 호출 실패를 어떻게 핸들링 해야 할 지 논의가 필요합니다.

## 🎸 기타
- 로그아웃 성공시 리다이렉트 할 프론트 홈페이지의 주소가 필요합니다.