### PR TITLE
KM-38 fix: 활성코드 초기화시 관리자 세션 유지

### DIFF
--- a/src/main/java/kkomo/admin/service/AdminCommandService.java
+++ b/src/main/java/kkomo/admin/service/AdminCommandService.java
@@ -37,7 +37,8 @@ public class AdminCommandService {
             .stream()
             .filter(UserPrincipal.class::isInstance)
             .map(UserPrincipal.class::cast)
-            .filter(UserPrincipal::isActivated)
+            .filter(principal ->
+                    principal.isActivated() && !principal.isAdmin())
             .forEach(principal ->
                 sessionRegistry.getAllSessions(principal, false)
                     .forEach(SessionInformation::expireNow));

--- a/src/main/java/kkomo/auth/UserPrincipal.java
+++ b/src/main/java/kkomo/auth/UserPrincipal.java
@@ -43,6 +43,10 @@ public class UserPrincipal implements OAuth2User {
         return member.isActivated();
     }
 
+    public boolean isAdmin() {
+        return member.isAdmin();
+    }
+
     public Long getId() {
         return member.getId();
     }


### PR DESCRIPTION
## ✨ 구현한 기능
- 활성코드 재발급시 admin 세션 삭제되는 로직 수정

## 📢 논의하고 싶은 내용
- 

## 🎸 기타
- 