### PR TITLE
KM-39 fix: OTT 여석 검색 시 프로필 중복 오류 발생

### DIFF
--- a/src/main/java/kkomo/ott/repository/OTTQueryDslRepository.java
+++ b/src/main/java/kkomo/ott/repository/OTTQueryDslRepository.java
@@ -1,6 +1,8 @@
 package kkomo.ott.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import kkomo.global.support.QueryDslSupport;
 import kkomo.ott.domain.OTT;
 import kkomo.ott.domain.OTTIdAndProfileIds;
@@ -27,12 +29,17 @@ class OTTQueryDslRepository extends QueryDslSupport implements OTTQueryRepositor
         return queryFactory.select(ott)
             .from(ott)
             .join(ott.profiles, profile).fetchJoin()
-            .leftJoin(reservation).on(reservation.ott.eq(ott)
-                .and(reservation.profile.eq(profile))
-                .and(reservation.time.start.goe(time.getStart()))
-                .and(reservation.time.end.loe(time.getEnd())))
-            .where(ottIdEqAndProfileIdsInOr(otts))
+            .where(ottIdEqAndProfileIdsInOr(otts), notReservedAt(time))
             .fetch();
+    }
+
+    private BooleanExpression notReservedAt(final OTTReservationTime time) {
+        return ott.id.notIn(
+            JPAExpressions.select(reservation.ott.id)
+                .from(reservation)
+                .where(reservation.time.start.goe(time.getStart())
+                    .and(reservation.time.end.loe(time.getEnd())))
+        );
     }
 
     private BooleanBuilder ottIdEqAndProfileIdsInOr(final List<OTTIdAndProfileIds> otts) {


### PR DESCRIPTION
## ✨ 구현한 기능
- 사용자가 요청한 시작 시간과 종료 시간 내에 예약이 없는 OTT를 검색하도록 변경
- OTT 여석 검색 시 프로필 중복 오류 발생

## 📢 논의하고 싶은 내용
- 

## 🎸 기타
- 